### PR TITLE
Unique slug generator, with documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A trait you can apply to Eloquent models to have slugs automatically generated on save.
 
 <br>
-<br>
 
 ## Installation
 
@@ -46,7 +45,7 @@ If you need to change these, you can do so via class constants:
 ### Regenerating Slugs ###
 By default, the trait will not overwrite slugs if there is already a value in the model's slug column. To override, this feature, the slug column should be set to null prior to calling the model's save function. E.g.
 
-    $mymodel-> = '';
+    $mymodel->myslugcolumn = '';
     $mymodel->save();
 
 
@@ -85,7 +84,8 @@ To generate a runtime prefix to prepend to the slug counter when generating a un
     
     	const SLUGGABLE_SLUG_COLUMN = 'headline';
     	const SLUGGABLE_NAME_COLUMN = 'seo_url';
-		const SLUGGABLE_UNIQUE_PREFIXER = 'news';  // this will be ignored if a method is present
+		// SLUGGABLE_UNIQUE_PREFIXER will be ignored if a sluggableUniquePrefixer method is present
+		const SLUGGABLE_UNIQUE_PREFIXER = 'news';  
 
 
 	    public function sluggableUniquePrefixer() {
@@ -98,7 +98,6 @@ To generate a runtime prefix to prepend to the slug counter when generating a un
 
 
 
-<br>
 <br>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2,43 +2,104 @@
 
 A trait you can apply to Eloquent models to have slugs automatically generated on save.
 
+<br>
+<br>
+
 ## Installation
 
     $ composer require martinbean/laravel-sluggable-trait
 
+<br>
 ## Usage
 
-```php
-<?php namespace App;
-
-use Illuminate\Database\Eloquent\Model;
-use MartinBean\Database\Elouqent\Sluggable;
-
-class Item extends Model {
-
-	use Sluggable;
-
-}
-```
+    <?php namespace App;
+    
+    use Illuminate\Database\Eloquent\Model;
+    use MartinBean\Database\Elouqent\Sluggable;
+    
+    class Item extends Model {
+    
+    	use Sluggable;
+    
+    }
+    
 
 By default, the trait assumes your database has two columns: `name` and `slug`.
 If you need to change these, you can do so via class constants:
 
-```php
-<?php namespace App;
+    
+    <?php namespace App;
+    
+    use Illuminate\Database\Eloquent\Model;
+    use MartinBean\Database\Elouqent\Sluggable;
+    
+    class Item extends Model {
+    
+    	use Sluggable;
+    
+    	const SLUGGABLE_SLUG_COLUMN = 'headline';
+    	const SLUGGABLE_NAME_COLUMN = 'seo_url';
+    
+    }
+    
+<br>
+### Regenerating Slugs ###
+By default, the trait will not overwrite slugs if there is already a value in the model's slug column. To override, this feature, the slug column should be set to null prior to calling the model's save function. E.g.
 
-use Illuminate\Database\Eloquent\Model;
-use MartinBean\Database\Elouqent\Sluggable;
+    $mymodel-> = '';
+    $mymodel->save();
 
-class Item extends Model {
 
-	use Sluggable;
+<br>
+### Unique Slugs ###
 
-	const DISPLAY_NAME = 'headline';
-	const SLUG = 'seo_url';
+The trait supports the generation of unique traits by adding a hexidecimal counter to the end of the slug name if the slug already exists. The counter can also be prefixed with a static OR dynamically generated value. To use a static prefix on the counter, in your model use:
 
-}
-```
+    
+    <?php namespace App;
+    
+    use Illuminate\Database\Eloquent\Model;
+    use MartinBean\Database\Elouqent\Sluggable;
+    
+    class Item extends Model {
+    
+    	use Sluggable;
+    
+    	const SLUGGABLE_SLUG_COLUMN = 'headline';
+    	const SLUGGABLE_NAME_COLUMN = 'seo_url';
+		const SLUGGABLE_UNIQUE_PREFIXER = 'news';
+
+    }
+    
+To generate a runtime prefix to prepend to the slug counter when generating a unique slug, you may define a function *sluggableUniquePrefixer* in your model code that may return a value, based on your model's values. For example:
+
+
+    <?php namespace App;
+    
+    use Illuminate\Database\Eloquent\Model;
+    use MartinBean\Database\Elouqent\Sluggable;
+    
+    class Item extends Model {
+    
+    	use Sluggable;
+    
+    	const SLUGGABLE_SLUG_COLUMN = 'headline';
+    	const SLUGGABLE_NAME_COLUMN = 'seo_url';
+		const SLUGGABLE_UNIQUE_PREFIXER = 'news';  // this will be ignored if a method is present
+
+
+	    public function sluggableUniquePrefixer() {
+	        if ($this->author)
+	            return substr($this->author->firstName,0,1).substr($this->author->lastName,0,1);
+	        return '';
+	    }
+
+    }
+
+
+
+<br>
+<br>
 
 ## License
 

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -18,7 +18,7 @@ trait Sluggable {
 		$callback = function(Model $model) use ($name, $slug)
 		{
             // Generate a unique slug, only if the slug is not already set
-            if ($model->slug == '') {
+            if ($model->$slug == '') {
                 $workingSlug = Str::slug($model->$name);
                 $workingModel = clone $model; // work with a cloned copy of the model for testing existing slugs
                 $count = 0;

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -17,7 +17,17 @@ trait Sluggable {
 
 		$callback = function(Model $model) use ($name, $slug)
 		{
-			$model->$slug = Str::slug($model->$name);
+            // Generate a unique slug, only if the slug is not already set
+            if ($model->slug == '') {
+                $workingSlug = Str::slug($model->$name);
+                $workingModel = clone $model; // work with a cloned copy of the model for testing existing slugs
+                $count = 0;
+                while ($row = $workingModel->where($slug, '=', $workingSlug)->first()) {
+                    $count += 1;
+                    $workingSlug = Str::slug($model->$name . self::getSlugUniquePrefixer($model) . dechex($count));
+                }
+                $model->$slug = $workingSlug;
+            }
 		};
 
 		static::registerModelEvent('saving', $callback, 0);
@@ -30,7 +40,7 @@ trait Sluggable {
 	 */
 	public static function getDisplayNameColumn()
 	{
-		return defined('static::DISPLAY_NAME') ? static::DISPLAY_NAME : 'name';
+		return defined('static::SLUGGABLE_NAME_COLUMN') ? static::SLUGGABLE_NAME_COLUMN : 'name';
 	}
 
 	/**
@@ -40,7 +50,22 @@ trait Sluggable {
 	 */
 	public static function getSlugColumn()
 	{
-		return defined('static::SLUG') ? static::SLUG : 'slug';
+		return defined('static::SLUGGABLE_SLUG_COLUMN') ? static::SLUGGABLE_SLUG_COLUMN : 'slug';
 	}
+
+    /**
+     * Get the name of the slug prefix to prepend to incrementer.
+     *
+     * @return string
+     */
+    public static function getSlugUniquePrefixer(Model $model)
+    {
+        // The model may have a function defined that returns a dynamic prefix for the uniquely generated slug
+        if (method_exists($model, 'sluggableUniquePrefixer')) {
+            debug($model->sluggableUniquePrefixer());
+            return $model->sluggableUniquePrefixer();
+        }
+        return defined('static::SLUGGABLE_UNIQUE_PREFIXER') ? static::SLUGGABLE_UNIQUE_PREFIXER : '';
+    }
 
 }


### PR DESCRIPTION
Per the documentation updates, I've enhanced the trait to create unique slugs and allowed for option static OR dynamic prefixing of a hex counter that gets added to the end of the generated slug.

I've modified the constant names to make it play nicer with other traits.
