### PR TITLE
Add support to pre-set slug

### DIFF
--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -17,7 +17,9 @@ trait Sluggable {
 
 		$callback = function(Model $model) use ($name, $slug)
 		{
-			$model->$slug = Str::slug($model->$name);
+			$model->$slug = isset($model->$slug)
+				? Str::slug($model->$slug)
+				: Str::slug($model->$name);
 		};
 
 		static::registerModelEvent('saving', $callback, 0);


### PR DESCRIPTION
I often have to enable the `slug` field to be passed when creating a entry on the DB, and this trait always overwrites it to the `$model->$name` slug 😢 

This change allows it, while still making sure it's a slug.

Thanks for this handy trait btw! 

🍻 
